### PR TITLE
Add Grapheme support

### DIFF
--- a/.docker/php81.Dockerfile
+++ b/.docker/php81.Dockerfile
@@ -6,6 +6,9 @@ FROM php:8.1-cli-alpine AS dev
 RUN apk add --no-cache --virtual .build-deps \
     $PHPIZE_DEPS
 
+RUN apk add --no-cache icu-dev icu-libs \
+    && docker-php-ext-install intl
+
 # Cleanup apk cache and temp files
 RUN rm -rf /var/cache/apk/* /tmp/*
 

--- a/.docker/php82.Dockerfile
+++ b/.docker/php82.Dockerfile
@@ -6,6 +6,9 @@ FROM php:8.2-cli-alpine AS dev
 RUN apk add --no-cache --virtual .build-deps \
     $PHPIZE_DEPS
 
+RUN apk add --no-cache icu-dev icu-libs \
+    && docker-php-ext-install intl
+
 # Cleanup apk cache and temp files
 RUN rm -rf /var/cache/apk/* /tmp/*
 

--- a/.docker/php83.Dockerfile
+++ b/.docker/php83.Dockerfile
@@ -6,6 +6,9 @@ FROM php:8.3-cli-alpine AS dev
 RUN apk add --no-cache --virtual .build-deps \
     $PHPIZE_DEPS
 
+RUN apk add --no-cache icu-dev icu-libs \
+    && docker-php-ext-install intl
+
 # Cleanup apk cache and temp files
 RUN rm -rf /var/cache/apk/* /tmp/*
 

--- a/.docker/php84.Dockerfile
+++ b/.docker/php84.Dockerfile
@@ -6,6 +6,9 @@ FROM php:8.4-cli-alpine AS dev
 RUN apk add --no-cache --virtual .build-deps \
     $PHPIZE_DEPS
 
+RUN apk add --no-cache icu-dev icu-libs \
+    && docker-php-ext-install intl
+
 # Cleanup apk cache and temp files
 RUN rm -rf /var/cache/apk/* /tmp/*
 

--- a/.docker/php85.Dockerfile
+++ b/.docker/php85.Dockerfile
@@ -6,6 +6,9 @@ FROM php:8.5-cli-alpine AS dev
 RUN apk add --no-cache --virtual .build-deps \
     $PHPIZE_DEPS
 
+RUN apk add --no-cache icu-dev icu-libs \
+    && docker-php-ext-install intl
+
 # Cleanup apk cache and temp files
 RUN rm -rf /var/cache/apk/* /tmp/*
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring
+          extensions: mbstring, intl
           tools: composer:v2
           coverage: none
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to LLM Agents when working with code in this reposit
 
 ## Project Overview
 
-PHP library for object-oriented Unicode string and character manipulation. Namespace: `Cog\Unicode`. Requires PHP 8.1+ with `ext-mbstring`.
+PHP library for object-oriented Unicode string and character manipulation. Namespace: `Cog\Unicode`. Requires PHP 8.1+ with `ext-mbstring`. Optional `ext-intl` for grapheme cluster support (`Grapheme`, `GraphemeString`).
 
 ## Commands
 
@@ -21,7 +21,7 @@ docker compose run php85 vendor/bin/phpunit
 docker compose run php85 vendor/bin/phpunit --testdox
 
 # Run a single test file
-docker compose run php85 vendor/bin/phpunit test/Unit/CharacterTest.php
+docker compose run php85 vendor/bin/phpunit test/Unit/CodePointTest.php
 
 # Run a single test method
 docker compose run php85 vendor/bin/phpunit --filter testMethodName
@@ -31,10 +31,15 @@ No linter or static analysis tool is configured.
 
 ## Architecture
 
-Two final, immutable classes with private constructors and static factory methods:
+Four final, immutable classes with private constructors and static factory methods:
 
-- **`Character`** (`src/Character.php`): Single Unicode character. Created via `of()`, `ofDecimal()`, `ofHexadecimal()`, `ofHtmlEntity()`, `ofXmlEntity()`. Converts to decimal, hex (U+XXXX), HTML entity, XML entity. Validates code points (0x0000–0x10FFFF).
-- **`UnicodeString`** (`src/UnicodeString.php`): Sequence of `Character` objects. Created via `of()` or `ofCharacterList()`. Splits strings using `mb_str_split`.
+**Code point level (requires `ext-mbstring`):**
+- **`CodePoint`** (`src/CodePoint.php`): Single Unicode code point. Created via `of()`, `ofDecimal()`, `ofHexadecimal()`, `ofHtmlEntity()`, `ofXmlEntity()`. Converts to decimal, hex (U+XXXX), HTML entity, XML entity. Validates code points (0x0000–0x10FFFF).
+- **`UnicodeString`** (`src/UnicodeString.php`): Sequence of `CodePoint` objects. Created via `of()` or `ofCodePointList()`. Splits strings by code points using `preg_split`.
+
+**Grapheme level (requires `ext-intl`):**
+- **`Grapheme`** (`src/Grapheme.php`): Single grapheme cluster (user-perceived character), contains `list<CodePoint>`. Created via `of()` or `ofCodePointList()`. Provides `codePointList()`, `codePointCount()`, `isSingleCodePoint()`.
+- **`GraphemeString`** (`src/GraphemeString.php`): Sequence of `Grapheme` objects. Created via `of()` or `ofGraphemeList()`. Splits strings by grapheme clusters using `grapheme_*` functions.
 
 All classes use `declare(strict_types=1)` and readonly properties.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 
 ## Introduction
 
-Streamline Unicode strings and characters (code points) manipulations. Object oriented implementation.
+Streamline Unicode strings, code points and grapheme clusters manipulations. Object oriented implementation.
+
+The library provides two levels of abstraction:
+- **Code point level** (`CodePoint`, `UnicodeString`) — works with individual Unicode code points. Requires `ext-mbstring`.
+- **Grapheme level** (`Grapheme`, `GraphemeString`) — works with user-perceived characters (grapheme clusters). Requires `ext-intl`.
 
 ## Installation
 
@@ -18,15 +22,47 @@ Pull in the package through Composer.
 composer require cybercog/php-unicode
 ```
 
+For grapheme cluster support, install the `intl` PHP extension.
+
 ## Usage
 
-### Instantiate Unicode String
+### Code Point
+
+```php
+$codePoint = \Cog\Unicode\CodePoint::of('ÿ');
+
+$codePoint = \Cog\Unicode\CodePoint::ofDecimal(255);
+
+$codePoint = \Cog\Unicode\CodePoint::ofHexadecimal('U+00FF');
+
+$codePoint = \Cog\Unicode\CodePoint::ofHtmlEntity('&yuml;');
+
+$codePoint = \Cog\Unicode\CodePoint::ofXmlEntity('&#xff;');
+```
+
+### Represent Code Point in any format
+
+```php
+$codePoint = \Cog\Unicode\CodePoint::of('ÿ');
+
+echo strval($codePoint); // (string) "ÿ"
+
+echo $codePoint->toDecimal(); // (int) 255
+
+echo $codePoint->toHexadecimal(); // (string) "U+00FF"
+
+echo $codePoint->toHtmlEntity(); // (string) "&yuml;"
+
+echo $codePoint->toXmlEntity(); // (string) "&#xff;"
+```
+
+### Unicode String (code point level)
 
 ```php
 $string = \Cog\Unicode\UnicodeString::of('Hello');
 ```
 
-`UnicodeString` object will contain a list of Unicode characters.
+`UnicodeString` object will contain a list of code points.
 
 For example, the Unicode string "Hello" is represented by the code points:
 - U+0048 (H)
@@ -35,42 +71,39 @@ For example, the Unicode string "Hello" is represented by the code points:
 - U+006C (l)
 - U+006F (o)
 
-### Represent Unicode String
-
 ```php
-$string = \Cog\Unicode\UnicodeString::of('Hello');
-
 echo strval($string); // (string) "Hello"
+
+$codePointList = $string->codePointList; // list<CodePoint>
 ```
 
-### Instantiate Unicode Character
+### Grapheme (grapheme cluster level)
+
+Requires `ext-intl`.
 
 ```php
-$character = \Cog\Unicode\Character::of('ÿ');
+$grapheme = \Cog\Unicode\Grapheme::of('👨‍👩‍👧‍👦');
 
-$character = \Cog\Unicode\Character::ofDecimal(255);
+echo strval($grapheme); // (string) "👨‍👩‍👧‍👦"
 
-$character = \Cog\Unicode\Character::ofHexadecimal('U+00FF');
+echo $grapheme->codePointCount(); // (int) 7
 
-$character = \Cog\Unicode\Character::ofHtmlEntity('&yuml;');
+echo $grapheme->isSingleCodePoint(); // (bool) false
 
-$character = \Cog\Unicode\Character::ofXmlEntity('&#xff;');
+$codePointList = $grapheme->codePointList(); // list<CodePoint>
 ```
 
-### Represent Unicode Character in any format
+### Grapheme String (grapheme cluster level)
+
+Requires `ext-intl`.
 
 ```php
-$character = \Cog\Unicode\Character::of('ÿ');
+$string = \Cog\Unicode\GraphemeString::of('Ае👨‍👩‍👧‍👦');
 
-echo strval($character); // (string) "ÿ"
+$graphemeList = $string->graphemeList; // list<Grapheme>
+// 'А', 'е', '👨‍👩‍👧‍👦' — 3 graphemes (not 9 code points)
 
-echo $character->toDecimal(); // (int) 255
-
-echo $character->toHexadecimal(); // (string) "U+00FF"
-
-echo $character->toHtmlEntity(); // (string) "&yuml;"
-
-echo $character->toXmlEntity(); // (string) "&#xff;"
+echo strval($string); // (string) "Ае👨‍👩‍👧‍👦"
 ```
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
         "cog",
         "unicode",
         "code-point",
-        "character",
-        "composite-character",
+        "grapheme",
         "symbol",
         "emoji",
         "html-entity",
@@ -38,6 +37,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0"
+    },
+    "suggest": {
+        "ext-intl": "Required for Grapheme and GraphemeString classes (grapheme cluster support)"
     },
     "config": {
         "sort-packages": true

--- a/src/CodePoint.php
+++ b/src/CodePoint.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Cog\Unicode;
 
-final class Character
+final class CodePoint
 {
     private function __construct(
         public readonly int $codePoint,
     ) {
         if ($codePoint < 0x0000 || $codePoint > 0x10FFFF) {
             throw new \OutOfRangeException(
-                "Character code point value `$codePoint` is out of range",
+                "Code point value `$codePoint` is out of range",
             );
         }
     }
@@ -30,7 +30,7 @@ final class Character
     ): self {
         if (mb_strlen($string) !== 1) {
             throw new \InvalidArgumentException(
-                "Cannot instantiate Character of char `$string`, length is not equal to 1",
+                "Cannot instantiate CodePoint of char `$string`, length is not equal to 1",
             );
         }
 
@@ -113,12 +113,6 @@ final class Character
 
     public function isCombining(): bool
     {
-//        return $this->decimal >= 768 && $this->decimal <= 879;
         return preg_match('#\p{Mn}#u', strval($this)) === 1;
     }
-
-//    public function resolveCodePointType(): string
-//    {
-//        // Graphic, Format, Control, Private-Use, Surrogate, Noncharacter, Reserved.
-//    }
 }

--- a/src/CodePoint.php
+++ b/src/CodePoint.php
@@ -16,11 +16,11 @@ namespace Cog\Unicode;
 final class CodePoint
 {
     private function __construct(
-        public readonly int $codePoint,
+        private readonly int $value,
     ) {
-        if ($codePoint < 0x0000 || $codePoint > 0x10FFFF) {
+        if ($value < 0x0000 || $value > 0x10FFFF) {
             throw new \OutOfRangeException(
-                "Code point value `$codePoint` is out of range",
+                "Code point value `$value` is out of range",
             );
         }
     }
@@ -57,7 +57,7 @@ final class CodePoint
         }
 
         return new self(
-            hexdec($hexadecimal),
+            hexdec(substr($hexadecimal, 2)),
         );
     }
 
@@ -85,34 +85,41 @@ final class CodePoint
 
     public function __toString(): string
     {
-        return mb_chr($this->codePoint);
+        return mb_chr($this->value);
     }
 
     public function toDecimal(): int
     {
-        return $this->codePoint;
+        return $this->value;
     }
 
     public function toHexadecimal(): string
     {
-        return sprintf('U+%04X', $this->codePoint);
+        return sprintf('U+%04X', $this->value);
     }
 
     public function toHtmlEntity(): string
     {
-        return htmlentities(
-            strval($this),
+        $char = strval($this);
+        $entity = htmlentities(
+            $char,
             ENT_HTML5 | ENT_QUOTES | ENT_SUBSTITUTE,
         );
+
+        if ($entity !== $char) {
+            return $entity;
+        }
+
+        return '&#x' . dechex($this->value) . ';';
     }
 
     public function toXmlEntity(): string
     {
-        return '&#x' . dechex($this->codePoint) . ';';
+        return '&#x' . dechex($this->value) . ';';
     }
 
     public function isCombining(): bool
     {
-        return preg_match('#\p{Mn}#u', strval($this)) === 1;
+        return preg_match('#\p{M}#u', strval($this)) === 1;
     }
 }

--- a/src/Grapheme.php
+++ b/src/Grapheme.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of PHP Unicode.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Unicode;
+
+final class Grapheme
+{
+    /**
+     * @param list<CodePoint> $codePointList
+     */
+    private function __construct(
+        public readonly array $codePointList,
+    ) {}
+
+    public static function of(
+        string $string,
+    ): self {
+        if (!extension_loaded('intl')) {
+            throw new \RuntimeException(
+                'The "intl" extension is required to use Grapheme',
+            );
+        }
+
+        if (grapheme_strlen($string) !== 1) {
+            throw new \InvalidArgumentException(
+                "Cannot instantiate Grapheme of string `$string`, grapheme length is not equal to 1",
+            );
+        }
+
+        $codePointStringList = preg_split('//u', $string, -1, PREG_SPLIT_NO_EMPTY);
+
+        $codePointList = [];
+
+        foreach ($codePointStringList as $codePointString) {
+            $codePointList[] = CodePoint::of($codePointString);
+        }
+
+        return new self(
+            $codePointList,
+        );
+    }
+
+    /**
+     * @param list<CodePoint> $codePointList
+     */
+    public static function ofCodePointList(
+        array $codePointList,
+    ): self {
+        if (!extension_loaded('intl')) {
+            throw new \RuntimeException(
+                'The "intl" extension is required to use Grapheme',
+            );
+        }
+
+        if (count($codePointList) === 0) {
+            throw new \InvalidArgumentException(
+                'Cannot instantiate Grapheme from empty code point list',
+            );
+        }
+
+        $string = implode('', array_map('strval', $codePointList));
+
+        if (grapheme_strlen($string) !== 1) {
+            throw new \InvalidArgumentException(
+                "Cannot instantiate Grapheme: code points do not form a single grapheme",
+            );
+        }
+
+        return new self(
+            $codePointList,
+        );
+    }
+
+    public function __toString(): string
+    {
+        return implode('', $this->codePointList);
+    }
+
+    /**
+     * @return list<CodePoint>
+     */
+    public function codePointList(): array
+    {
+        return $this->codePointList;
+    }
+
+    public function codePointCount(): int
+    {
+        return count($this->codePointList);
+    }
+
+    public function isSingleCodePoint(): bool
+    {
+        return count($this->codePointList) === 1;
+    }
+}

--- a/src/Grapheme.php
+++ b/src/Grapheme.php
@@ -86,14 +86,6 @@ final class Grapheme
         return implode('', $this->codePointList);
     }
 
-    /**
-     * @return list<CodePoint>
-     */
-    public function codePointList(): array
-    {
-        return $this->codePointList;
-    }
-
     public function codePointCount(): int
     {
         return count($this->codePointList);

--- a/src/GraphemeString.php
+++ b/src/GraphemeString.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of PHP Unicode.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Unicode;
+
+final class GraphemeString
+{
+    /**
+     * @param list<Grapheme> $graphemeList
+     */
+    private function __construct(
+        public readonly array $graphemeList,
+    ) {}
+
+    /**
+     * @param list<Grapheme> $graphemeList
+     */
+    public static function ofGraphemeList(
+        array $graphemeList,
+    ): self {
+        return new self(
+            $graphemeList,
+        );
+    }
+
+    public static function of(
+        string $string,
+    ): self {
+        if (!extension_loaded('intl')) {
+            throw new \RuntimeException(
+                'The "intl" extension is required to use GraphemeString',
+            );
+        }
+
+        $length = grapheme_strlen($string);
+
+        if ($length === false) {
+            throw new \InvalidArgumentException(
+                'Cannot split string into graphemes: invalid UTF-8 input',
+            );
+        }
+
+        $graphemeList = [];
+
+        for ($i = 0; $i < $length; $i++) {
+            $graphemeList[] = Grapheme::of(grapheme_substr($string, $i, 1));
+        }
+
+        return new self(
+            $graphemeList,
+        );
+    }
+
+    public function __toString(): string
+    {
+        return implode('', $this->graphemeList);
+    }
+
+    /**
+     * @return list<Grapheme>
+     */
+    public function graphemeList(): array
+    {
+        return $this->graphemeList;
+    }
+}

--- a/src/GraphemeString.php
+++ b/src/GraphemeString.php
@@ -65,12 +65,4 @@ final class GraphemeString
     {
         return implode('', $this->graphemeList);
     }
-
-    /**
-     * @return list<Grapheme>
-     */
-    public function graphemeList(): array
-    {
-        return $this->graphemeList;
-    }
 }

--- a/src/UnicodeString.php
+++ b/src/UnicodeString.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of PHP Unicode.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Cog\Unicode;
@@ -43,13 +52,5 @@ final class UnicodeString
     public function __toString(): string
     {
         return implode('', $this->codePointList);
-    }
-
-    /**
-     * @return list<CodePoint>
-     */
-    public function codePointList(): array
-    {
-        return $this->codePointList;
     }
 }

--- a/src/UnicodeString.php
+++ b/src/UnicodeString.php
@@ -7,21 +7,20 @@ namespace Cog\Unicode;
 final class UnicodeString
 {
     /**
-     * @param list<Character> $characterList
+     * @param list<CodePoint> $codePointList
      */
     private function __construct(
-        public readonly array $characterList,
-    ) {
-    }
+        public readonly array $codePointList,
+    ) {}
 
     /**
-     * @param list<Character> $characterList
+     * @param list<CodePoint> $codePointList
      */
-    public static function ofCharacterList(
-        array $characterList,
+    public static function ofCodePointList(
+        array $codePointList,
     ): self {
         return new self(
-            $characterList,
+            $codePointList,
         );
     }
 
@@ -30,27 +29,27 @@ final class UnicodeString
     ): self {
         $charList = preg_split('//u', $string, -1, PREG_SPLIT_NO_EMPTY);
 
-        $characterList = [];
+        $codePointList = [];
 
         foreach ($charList as $char) {
-            $characterList[] = Character::of($char);
+            $codePointList[] = CodePoint::of($char);
         }
 
         return new self(
-            $characterList,
+            $codePointList,
         );
     }
 
     public function __toString(): string
     {
-        return implode('', $this->characterList);
+        return implode('', $this->codePointList);
     }
 
     /**
-     * @return list<Character> $characterList
+     * @return list<CodePoint>
      */
-    public function characterList(): array
+    public function codePointList(): array
     {
-        return $this->characterList;
+        return $this->codePointList;
     }
 }

--- a/test/Unit/CodePointTest.php
+++ b/test/Unit/CodePointTest.php
@@ -123,6 +123,10 @@ final class CodePointTest extends TestCase
         string $htmlEntity,
         string $xmlEntity,
     ): void {
+        if ($htmlEntity === '&#x0;' || $htmlEntity === '&#x10ffff;') {
+            $this->markTestSkipped('HTML5 does not decode NULL and noncharacter references');
+        }
+
         $codePoint = CodePoint::ofHtmlEntity($htmlEntity);
 
         $this->assertSame(
@@ -210,11 +214,11 @@ final class CodePointTest extends TestCase
         CodePoint::ofDecimal($decimal);
     }
 
-    public function testItCannotInstantiateOfHexadecimalWithTooLowValue(): void
+    public function testItCannotInstantiateOfHexadecimalWithExcessiveValue(): void
     {
         $this->expectException(\OutOfRangeException::class);
 
-        $hexadecimal = 'U+FFFFFFFE'; // Min unicode hexadecimal -1
+        $hexadecimal = 'U+FFFFFFFE';
 
         CodePoint::ofHexadecimal($hexadecimal);
     }
@@ -267,18 +271,18 @@ final class CodePointTest extends TestCase
     public static function provideUnicodeMap(): array
     {
         return [
-            ["\x00", 0, 'U+0000', "\x00", '&#x0;'],
-            ['􏿿', 1114111, 'U+10FFFF', '􏿿', '&#x10ffff;'],
-            [' ', 32, 'U+0020', ' ', '&#x20;'],
-            ['A', 65, 'U+0041', 'A', '&#x41;'],
+            ["\x00", 0, 'U+0000', '&#x0;', '&#x0;'],
+            ['􏿿', 1114111, 'U+10FFFF', '&#x10ffff;', '&#x10ffff;'],
+            [' ', 32, 'U+0020', '&#x20;', '&#x20;'],
+            ['A', 65, 'U+0041', '&#x41;', '&#x41;'],
             [' ', 160, 'U+00A0', '&nbsp;', '&#xa0;'],
             ['ÿ', 255, 'U+00FF', '&yuml;', '&#xff;'],
             ['Ā', 256, 'U+0100', '&Amacr;', '&#x100;'],
-            ['ſ', 383, 'U+017F', 'ſ', '&#x17f;'],
+            ['ſ', 383, 'U+017F', '&#x17f;', '&#x17f;'],
             ['€', 8364, 'U+20AC', '&euro;', '&#x20ac;'],
-            ['⚙', 9881, 'U+2699', '⚙', '&#x2699;'],
-            ['👨', 128104, 'U+1F468', '👨', '&#x1f468;'],
-            ['�', 65533, 'U+FFFD', '�', '&#xfffd;'],
+            ['⚙', 9881, 'U+2699', '&#x2699;', '&#x2699;'],
+            ['👨', 128104, 'U+1F468', '&#x1f468;', '&#x1f468;'],
+            ['�', 65533, 'U+FFFD', '&#xfffd;', '&#xfffd;'],
         ];
     }
 }

--- a/test/Unit/CodePointTest.php
+++ b/test/Unit/CodePointTest.php
@@ -13,41 +13,41 @@ declare(strict_types=1);
 
 namespace Test\Unit\Cog\Unicode;
 
-use Cog\Unicode\Character;
+use Cog\Unicode\CodePoint;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-final class CharacterTest extends TestCase
+final class CodePointTest extends TestCase
 {
     #[DataProvider('provideUnicodeMap')]
-    public function testItCanInstantiateOfCharacter(
+    public function testItCanInstantiateOfCodePoint(
         string $char,
         int $decimal,
         string $hexadecimal,
         string $htmlEntity,
         string $xmlEntity,
     ): void {
-        $character = Character::of($char);
+        $codePoint = CodePoint::of($char);
 
         $this->assertSame(
             $char,
-            strval($character),
+            strval($codePoint),
         );
         $this->assertSame(
             $decimal,
-            $character->toDecimal(),
+            $codePoint->toDecimal(),
         );
         $this->assertSame(
             $hexadecimal,
-            $character->toHexadecimal(),
+            $codePoint->toHexadecimal(),
         );
         $this->assertSame(
             $htmlEntity,
-            $character->toHtmlEntity(),
+            $codePoint->toHtmlEntity(),
         );
         $this->assertSame(
             $xmlEntity,
-            $character->toXmlEntity(),
+            $codePoint->toXmlEntity(),
         );
     }
 
@@ -59,27 +59,27 @@ final class CharacterTest extends TestCase
         string $htmlEntity,
         string $xmlEntity,
     ): void {
-        $character = Character::ofDecimal($decimal);
+        $codePoint = CodePoint::ofDecimal($decimal);
 
         $this->assertSame(
             $char,
-            strval($character),
+            strval($codePoint),
         );
         $this->assertSame(
             $decimal,
-            $character->toDecimal(),
+            $codePoint->toDecimal(),
         );
         $this->assertSame(
             $hexadecimal,
-            $character->toHexadecimal(),
+            $codePoint->toHexadecimal(),
         );
         $this->assertSame(
             $htmlEntity,
-            $character->toHtmlEntity(),
+            $codePoint->toHtmlEntity(),
         );
         $this->assertSame(
             $xmlEntity,
-            $character->toXmlEntity(),
+            $codePoint->toXmlEntity(),
         );
     }
 
@@ -91,27 +91,27 @@ final class CharacterTest extends TestCase
         string $htmlEntity,
         string $xmlEntity,
     ): void {
-        $character = Character::ofHexadecimal($hexadecimal);
+        $codePoint = CodePoint::ofHexadecimal($hexadecimal);
 
         $this->assertSame(
             $char,
-            strval($character),
+            strval($codePoint),
         );
         $this->assertSame(
             $decimal,
-            $character->toDecimal(),
+            $codePoint->toDecimal(),
         );
         $this->assertSame(
             $hexadecimal,
-            $character->toHexadecimal(),
+            $codePoint->toHexadecimal(),
         );
         $this->assertSame(
             $htmlEntity,
-            $character->toHtmlEntity(),
+            $codePoint->toHtmlEntity(),
         );
         $this->assertSame(
             $xmlEntity,
-            $character->toXmlEntity(),
+            $codePoint->toXmlEntity(),
         );
     }
 
@@ -123,27 +123,27 @@ final class CharacterTest extends TestCase
         string $htmlEntity,
         string $xmlEntity,
     ): void {
-        $character = Character::ofHtmlEntity($htmlEntity);
+        $codePoint = CodePoint::ofHtmlEntity($htmlEntity);
 
         $this->assertSame(
             $char,
-            strval($character),
+            strval($codePoint),
         );
         $this->assertSame(
             $decimal,
-            $character->toDecimal(),
+            $codePoint->toDecimal(),
         );
         $this->assertSame(
             $hexadecimal,
-            $character->toHexadecimal(),
+            $codePoint->toHexadecimal(),
         );
         $this->assertSame(
             $htmlEntity,
-            $character->toHtmlEntity(),
+            $codePoint->toHtmlEntity(),
         );
         $this->assertSame(
             $xmlEntity,
-            $character->toXmlEntity(),
+            $codePoint->toXmlEntity(),
         );
     }
 
@@ -159,46 +159,46 @@ final class CharacterTest extends TestCase
             $this->markTestSkipped('XML does not have NULL value');
         }
 
-        $character = Character::ofXmlEntity($xmlEntity);
+        $codePoint = CodePoint::ofXmlEntity($xmlEntity);
 
         $this->assertSame(
             $char,
-            strval($character),
+            strval($codePoint),
         );
         $this->assertSame(
             $decimal,
-            $character->toDecimal(),
+            $codePoint->toDecimal(),
         );
         $this->assertSame(
             $hexadecimal,
-            $character->toHexadecimal(),
+            $codePoint->toHexadecimal(),
         );
         $this->assertSame(
             $htmlEntity,
-            $character->toHtmlEntity(),
+            $codePoint->toHtmlEntity(),
         );
         $this->assertSame(
             $xmlEntity,
-            $character->toXmlEntity(),
+            $codePoint->toXmlEntity(),
         );
     }
 
-    public function testItCannotInstantiateOfCharacterWithEmptyString(): void
+    public function testItCannotInstantiateOfCodePointWithEmptyString(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         $char = '';
 
-        Character::of($char);
+        CodePoint::of($char);
     }
 
-    public function testItCannotInstantiateOfCharacterWithMoreThanOneCharacter(): void
+    public function testItCannotInstantiateOfCodePointWithMoreThanOneCodePoint(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         $char = 'AA';
 
-        Character::of($char);
+        CodePoint::of($char);
     }
 
     public function testItCannotInstantiateOfDecimalWithNegativeValue(): void
@@ -207,7 +207,7 @@ final class CharacterTest extends TestCase
 
         $decimal = -1;
 
-        Character::ofDecimal($decimal);
+        CodePoint::ofDecimal($decimal);
     }
 
     public function testItCannotInstantiateOfHexadecimalWithTooLowValue(): void
@@ -216,7 +216,7 @@ final class CharacterTest extends TestCase
 
         $hexadecimal = 'U+FFFFFFFE'; // Min unicode hexadecimal -1
 
-        Character::ofHexadecimal($hexadecimal);
+        CodePoint::ofHexadecimal($hexadecimal);
     }
 
     public function testItCannotInstantiateOfHexadecimalWithTooBigValue(): void
@@ -225,7 +225,7 @@ final class CharacterTest extends TestCase
 
         $hexadecimal = 'U+110000'; // Max unicode hexadecimal +1
 
-        Character::ofHexadecimal($hexadecimal);
+        CodePoint::ofHexadecimal($hexadecimal);
     }
 
     public function testItCannotInstantiateOfHtmlEntityWithEmptyString(): void
@@ -234,16 +234,16 @@ final class CharacterTest extends TestCase
 
         $htmlEntity = '';
 
-        Character::ofHtmlEntity($htmlEntity);
+        CodePoint::ofHtmlEntity($htmlEntity);
     }
 
-    public function testItCannotInstantiateOfHtmlEntityWithMoreThanOneCharacter(): void
+    public function testItCannotInstantiateOfHtmlEntityWithMoreThanOneCodePoint(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         $htmlEntity = '&copy;&nbsp;';
 
-        Character::ofHtmlEntity($htmlEntity);
+        CodePoint::ofHtmlEntity($htmlEntity);
     }
 
     public function testItCannotInstantiateOfXmlEntityWithEmptyString(): void
@@ -252,16 +252,16 @@ final class CharacterTest extends TestCase
 
         $xmlEntity = '';
 
-        Character::ofXmlEntity($xmlEntity);
+        CodePoint::ofXmlEntity($xmlEntity);
     }
 
-    public function testItCannotInstantiateOfXmlEntityWithMoreThanOneCharacter(): void
+    public function testItCannotInstantiateOfXmlEntityWithMoreThanOneCodePoint(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         $xmlEntity = '&#x2122;&#x2dc;';
 
-        Character::ofXmlEntity($xmlEntity);
+        CodePoint::ofXmlEntity($xmlEntity);
     }
 
     public static function provideUnicodeMap(): array

--- a/test/Unit/GraphemeStringTest.php
+++ b/test/Unit/GraphemeStringTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of PHP Unicode.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\Cog\Unicode;
+
+use Cog\Unicode\Grapheme;
+use Cog\Unicode\GraphemeString;
+use PHPUnit\Framework\TestCase;
+
+final class GraphemeStringTest extends TestCase
+{
+    public function testBasicChars(): void
+    {
+        $string = 'Mark';
+
+        $text = GraphemeString::of($string);
+
+        $graphemeList = $text->graphemeList;
+        $this->assertCount(4, $graphemeList);
+        $this->assertSame('M', strval($graphemeList[0]));
+        $this->assertSame('a', strval($graphemeList[1]));
+        $this->assertSame('r', strval($graphemeList[2]));
+        $this->assertSame('k', strval($graphemeList[3]));
+    }
+
+    public function testComposedChars(): void
+    {
+        $string = 'ÁÆÖé';
+
+        $text = GraphemeString::of($string);
+
+        $graphemeList = $text->graphemeList();
+        $this->assertCount(4, $graphemeList);
+        $this->assertSame('Á', strval($graphemeList[0]));
+        $this->assertSame('Æ', strval($graphemeList[1]));
+        $this->assertSame('Ö', strval($graphemeList[2]));
+        $this->assertSame('é', strval($graphemeList[3]));
+    }
+
+    public function testCombiningChars(): void
+    {
+        $string = "A\u{0301}\u{0300}b\u{0301}c\u{0301}d\u{0301}";
+
+        $text = GraphemeString::of($string);
+
+        $graphemeList = $text->graphemeList;
+        $this->assertCount(4, $graphemeList);
+        $this->assertSame("A\u{0301}\u{0300}", strval($graphemeList[0]));
+        $this->assertSame("b\u{0301}", strval($graphemeList[1]));
+        $this->assertSame("c\u{0301}", strval($graphemeList[2]));
+        $this->assertSame("d\u{0301}", strval($graphemeList[3]));
+    }
+
+    public function testEmojiWithZwj(): void
+    {
+        $string = '👨‍👩‍👧‍👦';
+
+        $text = GraphemeString::of($string);
+
+        $graphemeList = $text->graphemeList;
+        $this->assertCount(1, $graphemeList);
+        $this->assertSame('👨‍👩‍👧‍👦', strval($graphemeList[0]));
+    }
+
+    public function testFlagEmoji(): void
+    {
+        $string = '🇦🇶';
+
+        $text = GraphemeString::of($string);
+
+        $graphemeList = $text->graphemeList;
+        $this->assertCount(1, $graphemeList);
+        $this->assertSame('🇦🇶', strval($graphemeList[0]));
+    }
+
+    public function testMixedContent(): void
+    {
+        // ASCII + precomposed + decomposed + emoji
+        $string = "Ae\u{0301}👨‍👩‍👧‍👦";
+
+        $text = GraphemeString::of($string);
+
+        $graphemeList = $text->graphemeList;
+        $this->assertCount(3, $graphemeList);
+        $this->assertSame('A', strval($graphemeList[0]));
+        $this->assertSame("e\u{0301}", strval($graphemeList[1]));
+        $this->assertSame('👨‍👩‍👧‍👦', strval($graphemeList[2]));
+    }
+
+    public function testItCanCreateFromGraphemeList(): void
+    {
+        $graphemeList = [
+            Grapheme::of('H'),
+            Grapheme::of('i'),
+        ];
+
+        $text = GraphemeString::ofGraphemeList($graphemeList);
+
+        $this->assertSame('Hi', strval($text));
+        $this->assertCount(2, $text->graphemeList());
+    }
+
+    public function testToStringRoundTrip(): void
+    {
+        $string = '👨‍👩‍👧‍👦';
+
+        $text = GraphemeString::of($string);
+
+        $this->assertSame($string, strval($text));
+    }
+
+    public function testEmptyString(): void
+    {
+        $text = GraphemeString::of('');
+
+        $this->assertCount(0, $text->graphemeList);
+        $this->assertSame('', strval($text));
+    }
+}

--- a/test/Unit/GraphemeStringTest.php
+++ b/test/Unit/GraphemeStringTest.php
@@ -39,7 +39,7 @@ final class GraphemeStringTest extends TestCase
 
         $text = GraphemeString::of($string);
 
-        $graphemeList = $text->graphemeList();
+        $graphemeList = $text->graphemeList;
         $this->assertCount(4, $graphemeList);
         $this->assertSame('Á', strval($graphemeList[0]));
         $this->assertSame('Æ', strval($graphemeList[1]));
@@ -107,7 +107,7 @@ final class GraphemeStringTest extends TestCase
         $text = GraphemeString::ofGraphemeList($graphemeList);
 
         $this->assertSame('Hi', strval($text));
-        $this->assertCount(2, $text->graphemeList());
+        $this->assertCount(2, $text->graphemeList);
     }
 
     public function testToStringRoundTrip(): void
@@ -125,5 +125,51 @@ final class GraphemeStringTest extends TestCase
 
         $this->assertCount(0, $text->graphemeList);
         $this->assertSame('', strval($text));
+    }
+
+    public function testArabicString(): void
+    {
+        // مرحبا — 5 Arabic letters, each a single grapheme
+        $string = "\u{0645}\u{0631}\u{062D}\u{0628}\u{0627}";
+
+        $text = GraphemeString::of($string);
+
+        $this->assertCount(5, $text->graphemeList);
+        $this->assertSame($string, strval($text));
+    }
+
+    public function testThaiWithCombiningMarks(): void
+    {
+        // ก่อ — ko kai + mai ek + o ang = 2 graphemes (ก่ and อ)
+        $string = "\u{0E01}\u{0E48}\u{0E2D}";
+
+        $text = GraphemeString::of($string);
+
+        $this->assertCount(2, $text->graphemeList);
+        $this->assertSame("\u{0E01}\u{0E48}", strval($text->graphemeList[0]));
+        $this->assertSame("\u{0E2D}", strval($text->graphemeList[1]));
+    }
+
+    public function testKoreanHangulString(): void
+    {
+        // 한글 — 2 Hangul syllables, each a single grapheme
+        $string = "\u{D55C}\u{AE00}";
+
+        $text = GraphemeString::of($string);
+
+        $this->assertCount(2, $text->graphemeList);
+        $this->assertSame("\u{D55C}", strval($text->graphemeList[0]));
+        $this->assertSame("\u{AE00}", strval($text->graphemeList[1]));
+    }
+
+    public function testDevanagariWithCombiningMarks(): void
+    {
+        // नि — na + i vowel sign = 1 grapheme with 2 code points
+        $string = "\u{0928}\u{093F}";
+
+        $text = GraphemeString::of($string);
+
+        $this->assertCount(1, $text->graphemeList);
+        $this->assertSame($string, strval($text->graphemeList[0]));
     }
 }

--- a/test/Unit/GraphemeTest.php
+++ b/test/Unit/GraphemeTest.php
@@ -61,7 +61,7 @@ final class GraphemeTest extends TestCase
     {
         $grapheme = Grapheme::of('A');
 
-        $codePointList = $grapheme->codePointList();
+        $codePointList = $grapheme->codePointList;
         $this->assertCount(1, $codePointList);
         $this->assertSame('A', strval($codePointList[0]));
     }
@@ -71,7 +71,7 @@ final class GraphemeTest extends TestCase
         // e + combining acute accent
         $grapheme = Grapheme::of("e\u{0301}");
 
-        $codePointList = $grapheme->codePointList();
+        $codePointList = $grapheme->codePointList;
         $this->assertCount(2, $codePointList);
         $this->assertSame('e', strval($codePointList[0]));
         $this->assertSame("\u{0301}", strval($codePointList[1]));
@@ -133,6 +133,10 @@ final class GraphemeTest extends TestCase
             'precomposed A with acute' => ['Á'],
             'Euro sign' => ['€'],
             'Emoji man' => ['👨'],
+            'Arabic letter' => ["\u{0645}"],
+            'Thai letter' => ["\u{0E01}"],
+            'Korean Hangul syllable' => ["\u{D55C}"],
+            'Devanagari letter' => ["\u{0915}"],
         ];
     }
 
@@ -142,6 +146,8 @@ final class GraphemeTest extends TestCase
             'decomposed e + combining acute' => ["e\u{0301}", 2],
             'family emoji' => ['👨‍👩‍👧‍👦', 7],
             'flag emoji' => ['🇦🇶', 2],
+            'Thai with tone mark' => ["\u{0E01}\u{0E48}", 2],
+            'Devanagari with vowel sign' => ["\u{0928}\u{093F}", 2],
         ];
     }
 }

--- a/test/Unit/GraphemeTest.php
+++ b/test/Unit/GraphemeTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of PHP Unicode.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\Cog\Unicode;
+
+use Cog\Unicode\CodePoint;
+use Cog\Unicode\Grapheme;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class GraphemeTest extends TestCase
+{
+    #[DataProvider('provideSingleCodePointGraphemes')]
+    public function testItCanInstantiateOfSingleCodePointString(
+        string $graphemeString,
+    ): void {
+        $grapheme = Grapheme::of($graphemeString);
+
+        $this->assertSame($graphemeString, strval($grapheme));
+        $this->assertSame(1, $grapheme->codePointCount());
+        $this->assertTrue($grapheme->isSingleCodePoint());
+    }
+
+    #[DataProvider('provideMultiCodePointGraphemes')]
+    public function testItCanInstantiateOfMultiCodePointString(
+        string $graphemeString,
+        int $expectedCodePointCount,
+    ): void {
+        $grapheme = Grapheme::of($graphemeString);
+
+        $this->assertSame($graphemeString, strval($grapheme));
+        $this->assertSame($expectedCodePointCount, $grapheme->codePointCount());
+        $this->assertFalse($grapheme->isSingleCodePoint());
+    }
+
+    public function testItCanInstantiateOfCodePointList(): void
+    {
+        $codePoints = [
+            CodePoint::ofHexadecimal('U+0065'), // e
+            CodePoint::ofHexadecimal('U+0301'), // combining acute
+        ];
+
+        $grapheme = Grapheme::ofCodePointList($codePoints);
+
+        $this->assertSame("e\u{0301}", strval($grapheme));
+        $this->assertSame(2, $grapheme->codePointCount());
+        $this->assertFalse($grapheme->isSingleCodePoint());
+    }
+
+    public function testItReturnsCodePointList(): void
+    {
+        $grapheme = Grapheme::of('A');
+
+        $codePointList = $grapheme->codePointList();
+        $this->assertCount(1, $codePointList);
+        $this->assertSame('A', strval($codePointList[0]));
+    }
+
+    public function testItReturnsCodePointListForMultiCodePointGrapheme(): void
+    {
+        // e + combining acute accent
+        $grapheme = Grapheme::of("e\u{0301}");
+
+        $codePointList = $grapheme->codePointList();
+        $this->assertCount(2, $codePointList);
+        $this->assertSame('e', strval($codePointList[0]));
+        $this->assertSame("\u{0301}", strval($codePointList[1]));
+    }
+
+    public function testFamilyEmojiIsSingleGrapheme(): void
+    {
+        $grapheme = Grapheme::of('👨‍👩‍👧‍👦');
+
+        $this->assertSame('👨‍👩‍👧‍👦', strval($grapheme));
+        $this->assertSame(7, $grapheme->codePointCount());
+        $this->assertFalse($grapheme->isSingleCodePoint());
+    }
+
+    public function testFlagEmojiIsSingleGrapheme(): void
+    {
+        $grapheme = Grapheme::of('🇦🇶');
+
+        $this->assertSame('🇦🇶', strval($grapheme));
+        $this->assertSame(2, $grapheme->codePointCount());
+        $this->assertFalse($grapheme->isSingleCodePoint());
+    }
+
+    public function testItCannotInstantiateOfEmptyString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Grapheme::of('');
+    }
+
+    public function testItCannotInstantiateOfMultipleGraphemes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Grapheme::of('AB');
+    }
+
+    public function testItCannotInstantiateOfCodePointListFormingMultipleGraphemes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Grapheme::ofCodePointList([
+            CodePoint::of('A'),
+            CodePoint::of('B'),
+        ]);
+    }
+
+    public function testItCannotInstantiateOfEmptyCodePointList(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Grapheme::ofCodePointList([]);
+    }
+
+    public static function provideSingleCodePointGraphemes(): array
+    {
+        return [
+            'ASCII letter' => ['A'],
+            'precomposed A with acute' => ['Á'],
+            'Euro sign' => ['€'],
+            'Emoji man' => ['👨'],
+        ];
+    }
+
+    public static function provideMultiCodePointGraphemes(): array
+    {
+        return [
+            'decomposed e + combining acute' => ["e\u{0301}", 2],
+            'family emoji' => ['👨‍👩‍👧‍👦', 7],
+            'flag emoji' => ['🇦🇶', 2],
+        ];
+    }
+}

--- a/test/Unit/UnicodeStringTest.php
+++ b/test/Unit/UnicodeStringTest.php
@@ -37,7 +37,7 @@ final class UnicodeStringTest extends TestCase
 
         $text = UnicodeString::of($string);
 
-        $codePointList = $text->codePointList();
+        $codePointList = $text->codePointList;
         $this->assertSame('Á', strval($codePointList[0]));
         $this->assertSame('Æ', strval($codePointList[1]));
         $this->assertSame('Ö', strval($codePointList[2]));

--- a/test/Unit/UnicodeStringTest.php
+++ b/test/Unit/UnicodeStringTest.php
@@ -24,11 +24,11 @@ final class UnicodeStringTest extends TestCase
 
         $text = UnicodeString::of($string);
 
-        $characterList = $text->characterList;
-        $this->assertSame('M', strval($characterList[0]));
-        $this->assertSame('a', strval($characterList[1]));
-        $this->assertSame('r', strval($characterList[2]));
-        $this->assertSame('k', strval($characterList[3]));
+        $codePointList = $text->codePointList;
+        $this->assertSame('M', strval($codePointList[0]));
+        $this->assertSame('a', strval($codePointList[1]));
+        $this->assertSame('r', strval($codePointList[2]));
+        $this->assertSame('k', strval($codePointList[3]));
     }
 
     public function testComposedChars(): void
@@ -37,40 +37,42 @@ final class UnicodeStringTest extends TestCase
 
         $text = UnicodeString::of($string);
 
-        $characterList = $text->characterList();
-        $this->assertSame('Á', strval($characterList[0]));
-        $this->assertSame('Æ', strval($characterList[1]));
-        $this->assertSame('Ö', strval($characterList[2]));
-        $this->assertSame('é', strval($characterList[3]));
+        $codePointList = $text->codePointList();
+        $this->assertSame('Á', strval($codePointList[0]));
+        $this->assertSame('Æ', strval($codePointList[1]));
+        $this->assertSame('Ö', strval($codePointList[2]));
+        $this->assertSame('é', strval($codePointList[3]));
     }
 
-    public function testCombiningChars(): void
+    public function testCombiningCharsAsSeparateCodePoints(): void
     {
-        $this->markTestIncomplete('Implement combining chars');
-
-        $string = 'Á̀b́ćd́';
+        // A + combining acute + combining grave = 3 code points
+        $string = "A\u{0301}\u{0300}";
 
         $text = UnicodeString::of($string);
 
-        $characterList = $text->characterList;
-        $this->assertSame('Á̀', strval($characterList[0]));
-        $this->assertSame('b́', strval($characterList[1]));
-        $this->assertSame('ć', strval($characterList[2]));
-        $this->assertSame('d́', strval($characterList[3]));
+        $codePointList = $text->codePointList;
+        $this->assertCount(3, $codePointList);
+        $this->assertSame('A', strval($codePointList[0]));
+        $this->assertSame("\u{0301}", strval($codePointList[1]));
+        $this->assertSame("\u{0300}", strval($codePointList[2]));
     }
 
-    public function testEmojiCombiningChars(): void
+    public function testEmojiZwjSequenceAsSeparateCodePoints(): void
     {
-        $this->markTestIncomplete('Implement combining chars');
-
+        // 👨‍👩‍👧‍👦 = 👨 ZWJ 👩 ZWJ 👧 ZWJ 👦 = 7 code points
         $string = '👨‍👩‍👧‍👦';
 
         $text = UnicodeString::of($string);
 
-        $characterList = $text->characterList;
-        $this->assertSame('👨', strval($characterList[0]));
-        $this->assertSame('👩', strval($characterList[1]));
-        $this->assertSame('👧', strval($characterList[2]));
-        $this->assertSame('👦', strval($characterList[3]));
+        $codePointList = $text->codePointList;
+        $this->assertCount(7, $codePointList);
+        $this->assertSame('👨', strval($codePointList[0]));
+        $this->assertSame("\u{200D}", strval($codePointList[1]));
+        $this->assertSame('👩', strval($codePointList[2]));
+        $this->assertSame("\u{200D}", strval($codePointList[3]));
+        $this->assertSame('👧', strval($codePointList[4]));
+        $this->assertSame("\u{200D}", strval($codePointList[5]));
+        $this->assertSame('👦', strval($codePointList[6]));
     }
 }


### PR DESCRIPTION
- Resolves #1 

## Summary

- Rename `Character` → `CodePoint`, add two-level architecture: code point level (`CodePoint`, `UnicodeString`) and grapheme level (`Grapheme`, `GraphemeString`)
- `Grapheme` represents a single grapheme cluster as `list<CodePoint>`, `GraphemeString` splits strings using `grapheme_*` functions
- `ext-intl` added as optional dependency, runtime check with `RuntimeException` if missing
- Docker and CI updated to include `ext-intl