### PR TITLE
Harden CodePoint validation and fix entity conversion contracts

### DIFF
--- a/src/CodePoint.php
+++ b/src/CodePoint.php
@@ -23,6 +23,12 @@ final class CodePoint
                 "Code point value `$value` is out of range",
             );
         }
+
+        if ($value >= 0xD800 && $value <= 0xDFFF) {
+            throw new \OutOfRangeException(
+                sprintf('Code point U+%04X is a surrogate and not a valid Unicode scalar value', $value),
+            );
+        }
     }
 
     public static function of(
@@ -64,23 +70,69 @@ final class CodePoint
     public static function ofHtmlEntity(
         string $htmlEntity,
     ): self {
-        return self::of(
-            html_entity_decode(
-                $htmlEntity,
-                ENT_HTML5 | ENT_QUOTES | ENT_SUBSTITUTE,
-            ),
+        if (preg_match('/^&([a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#x[0-9a-fA-F]+);$/', $htmlEntity) !== 1) {
+            throw new \InvalidArgumentException(
+                "Invalid HTML entity: $htmlEntity",
+            );
+        }
+
+        self::rejectSurrogateNumericEntity($htmlEntity);
+
+        $decoded = html_entity_decode(
+            $htmlEntity,
+            ENT_HTML5 | ENT_QUOTES | ENT_SUBSTITUTE,
         );
+
+        if ($decoded === $htmlEntity) {
+            throw new \InvalidArgumentException(
+                "Unknown HTML entity: $htmlEntity",
+            );
+        }
+
+        return self::of($decoded);
     }
 
     public static function ofXmlEntity(
         string $xmlEntity,
     ): self {
-        return self::of(
-            html_entity_decode(
-                $xmlEntity,
-                ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE,
-            ),
+        if (preg_match('/^&([a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#x[0-9a-fA-F]+);$/', $xmlEntity) !== 1) {
+            throw new \InvalidArgumentException(
+                "Invalid XML entity: $xmlEntity",
+            );
+        }
+
+        self::rejectSurrogateNumericEntity($xmlEntity);
+
+        $decoded = html_entity_decode(
+            $xmlEntity,
+            ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE,
         );
+
+        if ($decoded === $xmlEntity) {
+            throw new \InvalidArgumentException(
+                "Unknown XML entity: $xmlEntity",
+            );
+        }
+
+        return self::of($decoded);
+    }
+
+    private static function rejectSurrogateNumericEntity(
+        string $entity,
+    ): void {
+        if (preg_match('/^&#x([0-9a-fA-F]+);$/', $entity, $matches)) {
+            $value = hexdec($matches[1]);
+        } elseif (preg_match('/^&#([0-9]+);$/', $entity, $matches)) {
+            $value = (int) $matches[1];
+        } else {
+            return;
+        }
+
+        if ($value >= 0xD800 && $value <= 0xDFFF) {
+            throw new \InvalidArgumentException(
+                sprintf('%s references surrogate code point U+%04X', $entity, $value),
+            );
+        }
     }
 
     public function __toString(): string
@@ -110,12 +162,12 @@ final class CodePoint
             return $entity;
         }
 
-        return '&#x' . dechex($this->value) . ';';
+        return '&#x' . strtoupper(dechex($this->value)) . ';';
     }
 
     public function toXmlEntity(): string
     {
-        return '&#x' . dechex($this->value) . ';';
+        return '&#x' . strtoupper(dechex($this->value)) . ';';
     }
 
     public function isCombining(): bool

--- a/test/Unit/CodePointTest.php
+++ b/test/Unit/CodePointTest.php
@@ -123,7 +123,7 @@ final class CodePointTest extends TestCase
         string $htmlEntity,
         string $xmlEntity,
     ): void {
-        if ($htmlEntity === '&#x0;' || $htmlEntity === '&#x10ffff;') {
+        if ($htmlEntity === '&#x0;' || $htmlEntity === '&#x10FFFF;') {
             $this->markTestSkipped('HTML5 does not decode NULL and noncharacter references');
         }
 
@@ -268,21 +268,129 @@ final class CodePointTest extends TestCase
         CodePoint::ofXmlEntity($xmlEntity);
     }
 
+    #[DataProvider('provideSurrogateCodePoints')]
+    public function testItCannotInstantiateOfDecimalWithSurrogateCodePoint(
+        int $decimal,
+    ): void {
+        $this->expectException(\OutOfRangeException::class);
+        $this->expectExceptionMessage('is a surrogate');
+
+        CodePoint::ofDecimal($decimal);
+    }
+
+    #[DataProvider('provideSurrogateCodePoints')]
+    public function testItCannotInstantiateOfHexadecimalWithSurrogateCodePoint(
+        int $decimal,
+    ): void {
+        $this->expectException(\OutOfRangeException::class);
+        $this->expectExceptionMessage('is a surrogate');
+
+        CodePoint::ofHexadecimal(sprintf('U+%04X', $decimal));
+    }
+
+    public function testItCannotInstantiateOfHtmlEntityWithInvalidFormat(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid HTML entity');
+
+        CodePoint::ofHtmlEntity('hello');
+    }
+
+    public function testItCannotInstantiateOfHtmlEntityWithEmptyEntityName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid HTML entity');
+
+        CodePoint::ofHtmlEntity('&;');
+    }
+
+    public function testItCannotInstantiateOfHtmlEntityWithUnknownEntity(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown HTML entity');
+
+        CodePoint::ofHtmlEntity('&foobar;');
+    }
+
+    #[DataProvider('provideSurrogateEntities')]
+    public function testItCannotInstantiateOfHtmlEntityWithSurrogateCodePoint(
+        string $entity,
+    ): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('surrogate');
+
+        CodePoint::ofHtmlEntity($entity);
+    }
+
+    public function testItCannotInstantiateOfXmlEntityWithInvalidFormat(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid XML entity');
+
+        CodePoint::ofXmlEntity('hello');
+    }
+
+    public function testItCannotInstantiateOfXmlEntityWithEmptyEntityName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid XML entity');
+
+        CodePoint::ofXmlEntity('&;');
+    }
+
+    public function testItCannotInstantiateOfXmlEntityWithUnknownEntity(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown XML entity');
+
+        CodePoint::ofXmlEntity('&copy;');
+    }
+
+    #[DataProvider('provideSurrogateEntities')]
+    public function testItCannotInstantiateOfXmlEntityWithSurrogateCodePoint(
+        string $entity,
+    ): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('surrogate');
+
+        CodePoint::ofXmlEntity($entity);
+    }
+
+    public static function provideSurrogateEntities(): array
+    {
+        return [
+            '&#xD800;' => ['&#xD800;'],
+            '&#xDFFF;' => ['&#xDFFF;'],
+            '&#55296;' => ['&#55296;'],
+            '&#57343;' => ['&#57343;'],
+        ];
+    }
+
+    public static function provideSurrogateCodePoints(): array
+    {
+        return [
+            'U+D800 (high surrogate start)' => [0xD800],
+            'U+DBFF (high surrogate end)' => [0xDBFF],
+            'U+DC00 (low surrogate start)' => [0xDC00],
+            'U+DFFF (low surrogate end)' => [0xDFFF],
+        ];
+    }
+
     public static function provideUnicodeMap(): array
     {
         return [
             ["\x00", 0, 'U+0000', '&#x0;', '&#x0;'],
-            ['􏿿', 1114111, 'U+10FFFF', '&#x10ffff;', '&#x10ffff;'],
+            ['􏿿', 1114111, 'U+10FFFF', '&#x10FFFF;', '&#x10FFFF;'],
             [' ', 32, 'U+0020', '&#x20;', '&#x20;'],
             ['A', 65, 'U+0041', '&#x41;', '&#x41;'],
-            [' ', 160, 'U+00A0', '&nbsp;', '&#xa0;'],
-            ['ÿ', 255, 'U+00FF', '&yuml;', '&#xff;'],
+            [' ', 160, 'U+00A0', '&nbsp;', '&#xA0;'],
+            ['ÿ', 255, 'U+00FF', '&yuml;', '&#xFF;'],
             ['Ā', 256, 'U+0100', '&Amacr;', '&#x100;'],
-            ['ſ', 383, 'U+017F', '&#x17f;', '&#x17f;'],
-            ['€', 8364, 'U+20AC', '&euro;', '&#x20ac;'],
+            ['ſ', 383, 'U+017F', '&#x17F;', '&#x17F;'],
+            ['€', 8364, 'U+20AC', '&euro;', '&#x20AC;'],
             ['⚙', 9881, 'U+2699', '&#x2699;', '&#x2699;'],
-            ['👨', 128104, 'U+1F468', '&#x1f468;', '&#x1f468;'],
-            ['�', 65533, 'U+FFFD', '&#xfffd;', '&#xfffd;'],
+            ['👨', 128104, 'U+1F468', '&#x1F468;', '&#x1F468;'],
+            ['�', 65533, 'U+FFFD', '&#xFFFD;', '&#xFFFD;'],
         ];
     }
 }


### PR DESCRIPTION
## Summary

- Reject surrogate code points (U+D800–U+DFFF) in the `CodePoint` constructor — these are not valid Unicode scalar values
- Validate `ofHtmlEntity()` and `ofXmlEntity()` input format before passing to `html_entity_decode()`, with distinct "Invalid" vs "Unknown" error messages
- Intercept surrogate numeric entities (`&#xD800;`, `&#55296;`) before `html_entity_decode()` silently replaces them with U+FFFD
- `toHtmlEntity()` now always returns an entity: named if available, numeric hex (`&#xHEX;`) otherwise
- Normalize hex output to uppercase across `toHtmlEntity()` and `toXmlEntity()`

## Breaking changes

`toHtmlEntity()` previously returned the raw character when no named HTML5 entity existed. It now returns a numeric hex entity (e.g. `A` → `&#x41;`, `⚙` → `&#x2699;`). This fixes the method contract but changes its output.