### PR TITLE
Add explicit `Stringable` interface to all stringable classes

### DIFF
--- a/src/CodePoint.php
+++ b/src/CodePoint.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Unicode;
 
-final class CodePoint
+final class CodePoint implements \Stringable
 {
     private function __construct(
         private readonly int $value,

--- a/src/Grapheme.php
+++ b/src/Grapheme.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Unicode;
 
-final class Grapheme
+final class Grapheme implements \Stringable
 {
     /**
      * @param list<CodePoint> $codePointList

--- a/src/GraphemeString.php
+++ b/src/GraphemeString.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Unicode;
 
-final class GraphemeString
+final class GraphemeString implements \Stringable
 {
     /**
      * @param list<Grapheme> $graphemeList

--- a/src/UnicodeString.php
+++ b/src/UnicodeString.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Unicode;
 
-final class UnicodeString
+final class UnicodeString implements \Stringable
 {
     /**
      * @param list<CodePoint> $codePointList


### PR DESCRIPTION
All four classes (`CodePoint`, `UnicodeString`, `Grapheme`, `GraphemeString`) implement `__toString()` but don't explicitly declare `implements \Stringable`.

While PHP 8.0+ auto-implements `\Stringable` for classes with `__toString()`, adding the explicit declaration:

- Makes the public API self-documenting
- Improves IDE and static analysis support
- Makes class capabilities immediately visible when reading the code

### Changes

Added `implements \Stringable` to:
- `CodePoint`
- `UnicodeString`
- `Grapheme`
- `GraphemeString`

Fully backwards-compatible, no behavioral changes.